### PR TITLE
Update ex012.pl

### DIFF
--- a/lista02/ex012.pl
+++ b/lista02/ex012.pl
@@ -23,14 +23,11 @@ come(coelho, grama).
 come(veado, grama).
 come(urso, guaxinim).
 
-eh_predador(X, Y) :-
-    come(X, Y).
 
-eh_presa(X, Y) :-
-    come(Y, X).
-
-cadeia_alimentar(X) :-
-    (eh_predador(X, A) -> 
-    	write(X), write(' --> ');
-    	write(X), write(' --> '), writeln(' não tem presa.'), fail),
-    cadeia_alimentar(A).
+cadeia_alimentar(Predador, Presa):-
+	come(Predador, Presa),
+    write(Predador), write(' --> '), writeln(Presa).
+	
+cadeia_alimentar(Predador, Presa2):-
+    come(Predador, Presa),
+    cadeia_alimentar(Presa, Presa2).

--- a/lista02/ex012.pl
+++ b/lista02/ex012.pl
@@ -24,10 +24,16 @@ come(veado, grama).
 come(urso, guaxinim).
 
 
-cadeia_alimentar(Predador, Presa):-
+cadeia_alimentar(Predador):-
+	(come(Predador, Presa) -> 
+    	write(Predador), write(' --> ');
+    	write(Predador), write(' --> '), writeln(' não tem presa.'), fail),
+    cadeia_alimentar(Presa).
+    
+cadeia_alimentar_2_param(Predador, Presa):-
 	come(Predador, Presa),
     write(Predador), write(' --> '), writeln(Presa).
 	
-cadeia_alimentar(Predador, Presa2):-
+cadeia_alimentar_2_param(Predador, Presa2):-
     come(Predador, Presa),
     cadeia_alimentar(Presa, Presa2).


### PR DESCRIPTION
a versão anterior retornava apenas uma das cadeias alimentares do animal. Por exemplo, ao listar a cadeira alimentar do urso, seguia listava que o urso comia apenas peixe, quando na vdd também come raposa e veado, listando suas respectivas cadeias tbm.